### PR TITLE
Dockerfile: add blueos.local host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,9 @@ LABEL permissions='{\
     "80/tcp": {}\
   },\
   "HostConfig": {\
+    "ExtraHosts": [\
+      "blueos.local:host-gateway"\
+    ],\
     "Privileged": true,\
     "Binds": [\
       "/usr/blueos/userdata/openvscode/.cache:/home/workspace/.cache:rw",\


### PR DESCRIPTION
Makes blueos.local a host in the docker container, that will point to BlueOS itself in the internal network created by docker